### PR TITLE
Schema-related fixes

### DIFF
--- a/silasdk/client.py
+++ b/silasdk/client.py
@@ -28,7 +28,7 @@ class App():
             None
         """
         endpoint = endPoints["schemaUrl"]
-        message = ["header", "issue", "redeem", "transfer", "entity", "identity", "crypto", "linkAccount"]
+        message = ["header", "entity", "identity", "crypto", "linkAccount"]
         for i in message:
             response = self.get(
                 endpoint % i)

--- a/silasdk/ethwallet.py
+++ b/silasdk/ethwallet.py
@@ -2,32 +2,41 @@ from eth_account import Account
 import sha3
 import json
 
+from typing import Dict, Union
 
-class EthWallet():
 
+class EthWallet:
+
+    @staticmethod
     def create(entropy=''):
-        """create an ethereum wallet for user
-                This will generate a private key and ethereum address, that can be used for trasaction,
-                however this not a recommended way to create your wallets
-                Args:
-                entropy : provide randomness to gnerate the wallet
-                Returns:
-                tuple: response body with ethereum address and private key
-                """
+        """Create an Ethereum wallet for a user.
+
+        This will generate a private key and ethereum address, that can be used for trasaction,
+        however this not a recommended way to create your wallets
+        Args:
+        entropy : provide randomness to gnerate the wallet
+        Returns:
+        tuple: response body with ethereum address and private key
+        """
         account = Account.create(entropy)
         return {"eth_private_key": account.privateKey.hex(), "eth_address": account.address}
 
-    def signMessage(msg, key=None):
-        """Sign the message using an ethereum private key
-                This method signs the message for the user authentication mechanism
-                Args:
-                msg: message to be signed 
-                private_key: the key can be an app key or a user key used to sign the message
-                Returns:
-                string: a signed message
-                """
+    @staticmethod
+    def signMessage(msg: Union[str, Dict], key=None):
+        """Sign the message using an Ethereum private key.
+
+        This method signs the message for the user authentication mechanism
+        Args:
+        msg: message to be signed
+        private_key: the key can be an app key or a user key used to sign the message
+        Returns:
+        string: a signed message
+        """
         k = sha3.keccak_256()
-        encoded_message = (json.dumps(msg)).encode("utf-8")
+        if isinstance(msg, str):
+            encoded_message = msg.encode('utf-8')
+        else:
+            encoded_message = (json.dumps(msg)).encode("utf-8")
         k.update(encoded_message)
         message_hash = k.hexdigest()
         if key is not None:
@@ -38,38 +47,22 @@ class EthWallet():
         else:
             return " "
 
-    def signMessageAddress(msg, key=None):
-        """Sign the message using an ethereum private key
-                This method signs the message for the user authentication mechanism
-                Args:
-                msg: message to be signed
-                private_key: the key can be an app key or a user key used to sign the message
-                Returns:
-                string: a signed message
-                """
-        k = sha3.keccak_256()
-        encoded_message = msg.encode("utf-8")
-        k.update(encoded_message)
-        message_hash = k.hexdigest()
-        if key is not None:
-            signed_message = Account.signHash(message_hash, key)
-            sig_hx = signed_message.signature.hex()
-            return str(sig_hx.replace("0x", ""))
+    @staticmethod
+    def verifySignature(msg: Union[str, Dict], sign):
+        """Verify the message signature.
 
+        This method signs the message for the user authentication mechanism
+        Args:
+        msg: original message
+        sign : the signed hash obtained after signing the message with private key
+        Returns:
+        string: returns the Ethereum address corresponding to the private key the message was signed with
+        """
+        k = sha3.keccak_256()
+        if isinstance(msg, str):
+            encoded_message = msg.encode('utf-8')
         else:
-            return " "
-
-    def verifySignature(msg, sign):
-        """Verify the message signature
-                This method signs the message for the user authentication mechanism
-                Args:
-                msg: original message
-                sign : the signed hash obtained after signing the message with private key
-                Returns:
-                string: returns the ethereum address corresponding to the private key the message was signed with
-                """
-        k = sha3.keccak_256()
-        encoded_message = (json.dumps(msg)).encode("utf-8")
+            encoded_message = (json.dumps(msg)).encode("utf-8")
         k.update(encoded_message)
         message_hash = k.hexdigest()
         return Account.recoverHash(message_hash, signature=sign)

--- a/silasdk/message.py
+++ b/silasdk/message.py
@@ -1,6 +1,9 @@
 import time
 import uuid
+from copy import deepcopy
+from typing import Dict
 from .schema import Schema
+
 
 def getMessage(self, msg_type):
     """gets the message from schema 
@@ -10,7 +13,7 @@ def getMessage(self, msg_type):
     for i in Schema:
         for key, value in i.items():
             if key == msg_type:
-                return i[msg_type]
+                return deepcopy(i[msg_type])
 
 def lower_keys(x):
     """converts the payload dict keys to all lowercase to match schema
@@ -21,6 +24,17 @@ def lower_keys(x):
         return dict((k.lower(), v) for k, v in x.items())
     else:
         return "msg_fromat_incorrect"
+
+
+def cull_null_values(data: Dict) -> Dict:
+    for k, v in list(data.items()):
+        if isinstance(v, dict):
+            data[k] = cull_null_values(v)
+        elif v == '':
+            del data[k]
+
+    return data
+
 
 def createMessage(self, payload, msg_type):
     """creates the message to be sent based on payload from customer
@@ -45,6 +59,9 @@ def createMessage(self, payload, msg_type):
                 if key in data.keys():
                     inpt[i][key] = data[key]
     inpt["header"]["created"] = int(time.time())
+
+    inpt = cull_null_values(inpt)
+
     return inpt
 
 def postRequest(self, path, msg_type, payload, key=None):

--- a/silasdk/schema.py
+++ b/silasdk/schema.py
@@ -49,7 +49,7 @@ Schema = [
         },
         "account_name": ""
     }},
-    {"transfer_msg_address": {
+    {"transfer_msg": {
         "header": {
             "created": "",
             "auth_handle": "",
@@ -58,10 +58,44 @@ Schema = [
             "crypto": "ETH",
             "reference": ""
         },
-        "message": "transfer_msg_address",
-        "amount": 13,
+        "message": "transfer_msg",
+        "amount": "",
         "destination": "",
-        "destination_address": ""
+        "destination_handle": "",
+        "destination_wallet": "",
+        "destination_address": "",
+        "business_uuid": "",
+        "descriptor": ""
+    }},
+    {"issue_msg": {
+        "header": {
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
+            "version": "0.2",
+            "crypto": "ETH",
+            "reference": ""
+        },
+        "message": "issue_msg",
+        "amount": "",
+        "account_name": "",
+        "business_uuid": "",
+        "descriptor": ""
+    }},
+    {"redeem_msg": {
+        "header": {
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
+            "version": "0.2",
+            "crypto": "ETH",
+            "reference": ""
+        },
+        "message": "redeem_msg",
+        "amount": "",
+        "account_name": "",
+        "business_uuid": "",
+        "descriptor": ""
     }},
     {"no_content_msg": {
         "header": {

--- a/silasdk/schema.py
+++ b/silasdk/schema.py
@@ -2,113 +2,113 @@ Schema = [
     {"header_msg_kyc_level": {
         "header": {
             "reference": "",
-            "created": 1587419132,
+            "created": "",
             "user_handle": "",
             "auth_handle": "",
             "version": "0.2",
             "crypto": "ETH"
         },
-        "message": "header_msg_kyc_level",
-        "kyc_level": "CUSTOM_KYC_FLOW_NAME"
-    }},
-    {"link_account_msg": {
-        "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
-            "version": "0.2",
-            "crypto": "ETH",
-            "reference": "ref"
-        },
-        "message": "link_account_msg",
-        "public_token": "public-xxx-xxx",
-        "account_name": "Custom Account Name",
-        "selected_account_id": "optional_selected_account_id"
+        "message": "header_msg",
+        "kyc_level": ""
     }},
     {"link_account_msg_plaid": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
-        "message": "link_account_msg_plaid",
-        "account_number": "123456789012",
-        "routing_number": "123456789",
-        "account_type": "CHECKING",
-        "account_name": "Custom Account Name",
-        "selected_account_id": "0"
+        "message": "link_account_msg",
+        "public_token": "",
+        "account_name": "",
+        "selected_account_id": ""
+    }},
+    {"link_account_msg": {
+        "header": {
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
+            "version": "0.2",
+            "crypto": "ETH",
+            "reference": ""
+        },
+        "message": "link_account_msg",
+        "account_number": "",
+        "routing_number": "",
+        "account_type": "",
+        "account_name": "",
+        "selected_account_id": ""
     }},
     {"account_name_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
         },
-        "account_name": "Custom Account Name"
+        "account_name": ""
     }},
     {"transfer_msg_address": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
         "message": "transfer_msg_address",
         "amount": 13,
-        "destination": "user2.silamoney.eth",
-        "destination_address": "user2.silamoney.eth"
+        "destination": "",
+        "destination_address": ""
     }},
     {"no_content_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         }
     }},
     {"update_wallet_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
-        "nickname": "new_wallet_nickname",
-        "default": True
+        "nickname": "",
+        "default": False
     }},
     {"register_wallet_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
-        "wallet_verification_signature": "(signature generated from signing address as the message)",
+        "wallet_verification_signature": "",
         "wallet": {
-            "blockchain_address": "(address to register to user_handle)",
+            "blockchain_address": "",
             "blockchain_network": "ETH",
-            "nickname": "new_wallet_nickname"
+            "nickname": ""
         }
     }},
     {"get_wallets_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
         "search_filters": {
             "page": 1,
@@ -121,16 +121,16 @@ Schema = [
     }},
     {"get_accounts_msg": {
         "header": {
-            "created": 1234567890,
-            "auth_handle": "handle.silamoney.eth",
-            "user_handle": "user.silamoney.eth",
+            "created": "",
+            "auth_handle": "",
+            "user_handle": "",
             "version": "0.2",
             "crypto": "ETH",
-            "reference": "ref"
+            "reference": ""
         },
         "message": "get_accounts_msg"
     }},
     {"sila_balance_msg": {
-        "address": "0x0000"
+        "address": ""
     }}
 ]

--- a/silasdk/tests/test014_register_wallet.py
+++ b/silasdk/tests/test014_register_wallet.py
@@ -1,6 +1,6 @@
 import unittest
 
-from silasdk.stellarwallet import Wallet
+from silasdk.wallet import Wallet
 from silasdk.tests.test_config import *
 
 

--- a/silasdk/tests/test015_get_wallets.py
+++ b/silasdk/tests/test015_get_wallets.py
@@ -1,6 +1,6 @@
 import unittest
 
-from silasdk.stellarwallet import Wallet
+from silasdk.wallet import Wallet
 from silasdk.tests.test_config import *
 
 

--- a/silasdk/tests/test016_get_wallet.py
+++ b/silasdk/tests/test016_get_wallet.py
@@ -1,6 +1,6 @@
 import unittest
 
-from silasdk.stellarwallet import Wallet
+from silasdk.wallet import Wallet
 from silasdk.tests.test_config import *
 
 

--- a/silasdk/tests/test017_update_wallet.py
+++ b/silasdk/tests/test017_update_wallet.py
@@ -1,6 +1,6 @@
 import unittest
 
-from silasdk.stellarwallet import Wallet
+from silasdk.wallet import Wallet
 from silasdk.tests.test_config import *
 
 

--- a/silasdk/tests/test018_delete_wallet.py
+++ b/silasdk/tests/test018_delete_wallet.py
@@ -1,6 +1,6 @@
 import unittest
 
-from silasdk.stellarwallet import Wallet
+from silasdk.wallet import Wallet
 from silasdk.tests.test_config import *
 
 

--- a/silasdk/tests/test_config.py
+++ b/silasdk/tests/test_config.py
@@ -37,5 +37,5 @@ eth_private_key_2 = eth_2["eth_private_key"]
 wallet = EthWallet.create()
 wallet_address = wallet["eth_address"]
 wallet_private_key = wallet["eth_private_key"]
-verification_signature = EthWallet.signMessageAddress(wallet_address, wallet_private_key)
+verification_signature = EthWallet.signMessage(wallet_address, wallet_private_key)
 wallet_address_signed_verified = EthWallet.verifySignature(wallet_address, verification_signature)

--- a/silasdk/transactions.py
+++ b/silasdk/transactions.py
@@ -43,7 +43,7 @@ class Transaction():
             dict: response body (a confirmation message)
         """
         path = endPoints["transferSila"]
-        msg_type = ("transfer_msg" if (use_destination_address is False) else "transfer_msg_address")
+        msg_type = "transfer_msg"
         response = message.postRequest(self, path, msg_type, payload, user_private_key)
         return response
 


### PR DESCRIPTION
Schema contained test values instead of null values, so any values not
overridden at runtime where being forwarded to the API server.

Schema also contained references to messages not defined in the API server.

Replace all test values in the hard-coded local schema with null
strings, except for `update_wallet_msg->default` boolean, which is
hard-coded to the default `False` value, as defined in the backend
model.

Add `cull_null_values()` to drop null values from the payload before
sending.

Fix references in the unit tests to 'stellarwallet`, replace with
`wallet`.